### PR TITLE
loginObservable accepts redirect_uri as a parameter

### DIFF
--- a/epibox.js
+++ b/epibox.js
@@ -96,7 +96,7 @@ epibox.activeDivHtml = function () {
         <hr>
     </div>`
 }
-epibox.loginObservable = async function () {
+epibox.loginObservable = async function (redirect_uri="https://observablehq.com/@episphere/epibox") {
     epibox.readParms()
     epibox.loginObservableDiv = document.createElement('div')
     epibox.clearLog = function () { // reload page without parameters
@@ -131,7 +131,7 @@ epibox.loginObservable = async function () {
             epibox.observableToken()
             epibox.loginObservableDiv.innerHTML = `<h3>epiBox</h3>
             <p>
-            <button onclick="epibox.setURL('https://account.box.com/api/oauth2/authorize?client_id=${epibox.oauth.client_id}&response_type=code&redirect_uri=https://observablehq.com/@episphere/epibox')" style="background-color:yellow">Login Box</button>
+            <button onclick="epibox.setURL('https://account.box.com/api/oauth2/authorize?client_id=${epibox.oauth.client_id}&response_type=code&redirect_uri=${redirect_uri}')" style="background-color:yellow">Login Box</button>
             </p>&nbsp;`
         }
     }


### PR DESCRIPTION
Previously, the redirect_uri for the loginObservable flow was hardcoded to be Jonas's episphere/epibox Observable notebook. That would mean that no one else would be able to integrate it with their Observable notebook directly. Making it a parameter so that anyone with an Observable notebook might use it in theory (although they can't really, because they can't set the redirect_URI on the Box app without being given access to edit it.)